### PR TITLE
Fix issues breaking CD of the CI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+A work-in-progress CI server that aims to keep things simple and keep files cached locally.
+WIP documentation is dumped here below.
+
+Depends on binaries: bwrap, cp
+
+`/etc/sysctl.conf`
+
+```
+kernel.unprivileged_userns_clone = 1
+kernel.apparmor_restrict_unprivileged_userns = 0
+```
+
+Systemd service
+
+```ini
+[Unit]
+Description=Continuous Integration Server
+After=network.target
+
+[Service]
+User=ci-server
+Group=ci-server
+Type=simple
+# To stop, only kill the parent. This is required to keep the builder processes
+# running, to allow for upgrades without stopping builds.
+KillMode=process
+
+WorkingDirectory=/
+ExecStart=/usr/local/bin/ci-server --config /usr/local/etc/ci-server --lib /usr/local/share/ci-server
+Environment=PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
+EnvironmentFile=/usr/local/etc/ci-server/server-secrets.env
+
+StandardOutput=journal
+StandardError=inherit
+
+Restart=always
+RestartSec=5
+
+ProtectHome=true
+ProtectSystem=full
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+```

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -143,7 +144,7 @@ func build(log slog.Logger, p BuilderParams) (int, error) {
 	if p.CacheID != nil {
 		log.Info("Copying cache", slog.Uint64("cache_id", *p.CacheID))
 		cacheDir := getBuildDir(p.DataDir, *p.CacheID)
-		if err := os.CopyFS(buildDir, os.DirFS(cacheDir)); err != nil {
+		if err := copyDirs(cacheDir, buildDir); err != nil {
 			return 0, fmt.Errorf(
 				"failed to copy repo cache dir '%s' to build dir '%s': %w",
 				cacheDir, buildDir, err,
@@ -192,16 +193,30 @@ func build(log slog.Logger, p BuilderParams) (int, error) {
 	return exitCode, nil
 }
 
+func copyDirs(src, dst string) error {
+	// Use cp -a for archive copy (preserving most (all?) attributes and symlinks)
+	cpCmd := exec.Command("cp", "-a", src, dst)
+
+	out := &bytes.Buffer{}
+	cpCmd.Stdout = out
+	cpCmd.Stderr = out
+
+	if err := cpCmd.Run(); err != nil {
+		return fmt.Errorf("failed to copy dirs: w%\n\ncp output:\n%s", err, out)
+	}
+	return nil
+}
+
 func checkout(owner, name, commitSHA, targetDir string) error {
 	initCmd := exec.Command("git", "-C", targetDir, "init", "-q")
 	if err := initCmd.Run(); err != nil {
-		return fmt.Errorf("failed to init repo at '%s': %v", targetDir, err)
+		return fmt.Errorf("failed to init repo at '%s': %w", targetDir, err)
 	}
 
 	cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, name)
 	cloneCmd := exec.Command("git", "-C", targetDir, "fetch", "--depth=1", cloneURL, commitSHA)
 	if err := cloneCmd.Run(); err != nil {
-		return fmt.Errorf("failed to fetch repo at '%s': %v", cloneURL, err)
+		return fmt.Errorf("failed to fetch repo at '%s': %w", cloneURL, err)
 	}
 
 	// Check out repo files to build dir
@@ -212,7 +227,7 @@ func checkout(owner, name, commitSHA, targetDir string) error {
 		"checkout", commitSHA, "--", ".",
 	)
 	if err := checkoutCmd.Run(); err != nil {
-		return fmt.Errorf("failed to checkout commit for '%s': %v", cloneURL, err)
+		return fmt.Errorf("failed to checkout commit for '%s': %w", cloneURL, err)
 	}
 
 	return nil

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -175,6 +175,7 @@ func build(log slog.Logger, p BuilderParams) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	log.Info("Finished build command", slog.Int("exit_code", exitCode))
 
 	// Run deploy command - only if it exists and the build command was successful
 	if exitCode != 0 || len(p.DeployCmd) == 0 {
@@ -186,6 +187,7 @@ func build(log slog.Logger, p BuilderParams) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	log.Info("Finished deploy command", slog.Int("exit_code", exitCode))
 
 	return exitCode, nil
 }

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -137,18 +137,20 @@ func isBuilderRunning(pid int, buildID uint64) bool {
 func build(log slog.Logger, p BuilderParams) (int, error) {
 	buildDir := getBuildDir(p.DataDir, p.BuildID)
 
-	if err := os.Mkdir(buildDir, 0o700); err != nil {
-		return 0, fmt.Errorf("failed to create build dir: %w", err)
-	}
-
 	if p.CacheID != nil {
 		log.Info("Copying cache", slog.Uint64("cache_id", *p.CacheID))
 		cacheDir := getBuildDir(p.DataDir, *p.CacheID)
+		// Copying will create the build dir
 		if err := copyDirs(cacheDir, buildDir); err != nil {
 			return 0, fmt.Errorf(
 				"failed to copy repo cache dir '%s' to build dir '%s': %w",
 				cacheDir, buildDir, err,
 			)
+		}
+	} else {
+		// Create an empty build dir
+		if err := os.Mkdir(buildDir, 0o700); err != nil {
+			return 0, fmt.Errorf("failed to create build dir: %w", err)
 		}
 	}
 

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -145,8 +145,8 @@ func build(log slog.Logger, p BuilderParams) (int, error) {
 		cacheDir := getBuildDir(p.DataDir, *p.CacheID)
 		if err := os.CopyFS(buildDir, os.DirFS(cacheDir)); err != nil {
 			return 0, fmt.Errorf(
-				"failed to copy repo cache dir '%s' to build dir '%s'",
-				cacheDir, buildDir,
+				"failed to copy repo cache dir '%s' to build dir '%s': %w",
+				cacheDir, buildDir, err,
 			)
 		}
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ rsync -e "ssh ${SSH_OPTS}" -avz "./migrations" "./ui" "${REMOTE_HOST}:${BASE_DIR
 echo ""
 
 echo "Restarting service..."
-ssh ${SSH_OPTS} "${REMOTE_HOST}" "/usr/bin/systemctl restart ci.service"
+ssh ${SSH_OPTS} "${REMOTE_HOST}" "set -euxo pipefail; systemctl restart ci.service"
 echo ""
 
 echo "Done"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ if [ "$CI" = "true" ]; then
     eval "$(ssh-agent -s)" > /dev/null
 
     # Kill the agent when the script exits. $SSH_AGENT_PID is set by 'eval' above
-    trap "echo 'Stopping SSH Agent'; kill $SSH_AGENT_PID;" EXIT
+    trap "kill $SSH_AGENT_PID; echo 'Stopped SSH Agent';" EXIT
 
     if [ -z "$SSH_HOST_KEY" ]; then
         echo "ERROR: CI mode requires SSH_HOST_KEY environment variable." >&2
@@ -42,7 +42,7 @@ rsync -e "ssh ${SSH_OPTS}" -avz "./migrations" "./ui" "${REMOTE_HOST}:${BASE_DIR
 echo ""
 
 echo "Restarting service..."
-ssh ${SSH_OPTS} "${REMOTE_HOST}" "set -euxo pipefail; systemctl restart ci.service"
+ssh ${SSH_OPTS} "${REMOTE_HOST}" "systemctl restart ci.service"
 echo ""
 
 echo "Done"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ rsync -e "ssh ${SSH_OPTS}" -avz "./migrations" "./ui" "${REMOTE_HOST}:${BASE_DIR
 echo ""
 
 echo "Restarting service..."
-ssh ${SSH_OPTS} "${REMOTE_HOST}" "set -euxo pipefail; systemctl restart ci.service"
+ssh ${SSH_OPTS} "${REMOTE_HOST}" "/usr/bin/systemctl restart ci.service"
 echo ""
 
 echo "Done"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,7 @@ rsync -e "ssh ${SSH_OPTS}" -avz "./migrations" "./ui" "${REMOTE_HOST}:${BASE_DIR
 echo ""
 
 echo "Restarting service..."
-ssh ${SSH_OPTS} "${REMOTE_HOST}" "systemctl restart ci.service"
+ssh ${SSH_OPTS} "${REMOTE_HOST}" "set -euxo pipefail; systemctl restart ci.service"
 echo ""
 
 echo "Done"


### PR DESCRIPTION
- Document how to prevent a server restart from killing builder processes in Systemd
- Use `cp` to copy folders because `os.CopyFS` fails at symlinks sometimes