### PR TITLE
Simplify installation and improve security

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,38 +10,6 @@ kernel.unprivileged_userns_clone = 1
 kernel.apparmor_restrict_unprivileged_userns = 0
 ```
 
-Systemd service
-
-```ini
-[Unit]
-Description=Continuous Integration Server
-After=network.target
-
-[Service]
-User=ci-server
-Group=ci-server
-Type=simple
-# To stop, only kill the parent. This is required to keep the builder processes
-# running, to allow for upgrades without stopping builds.
-KillMode=process
-
-WorkingDirectory=/
-ExecStart=/usr/local/bin/ci-server --config /usr/local/etc/ci-server --lib /usr/local/share/ci-server
-Environment=PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
-EnvironmentFile=/usr/local/etc/ci-server/server-secrets.env
-
-StandardOutput=journal
-StandardError=inherit
-
-Restart=always
-RestartSec=5
-
-ProtectHome=true
-ProtectSystem=full
-NoNewPrivileges=true
-
-[Install]
-WantedBy=multi-user.target
-```
+Systemd service -> see ci.service
 
 Using [Fontawesome](https://fontawesome.com/) icons

--- a/ci.service
+++ b/ci.service
@@ -1,0 +1,33 @@
+# CI Server systemd service file
+[Unit]
+Description=Continuous Integration Server
+After=network.target
+
+[Service]
+User=ci-server
+Group=ci-server
+Type=simple
+# Only kill the parent to stop the server. This is required to keep the builder
+# processes running, to allow for upgrades without stopping builds.
+KillMode=process
+
+WorkingDirectory=/
+ExecStart=/opt/ci-server/ci-server --config /opt/ci-server/
+# Set the PATH to something controlled as this variable is passed on to the
+# builder processes. PostgreSQL binaries are included for tests that use
+# the database CLI tools.
+Environment=PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/lib/postgresql/16/bin'
+EnvironmentFile=/opt/ci-server/server-secrets.env
+
+StandardOutput=journal
+StandardError=inherit
+
+Restart=always
+RestartSec=5
+
+ProtectHome=true
+ProtectSystem=full
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,10 +3,9 @@
 
 set -e
 
-REMOTE_HOST="${1:-root@ci.ctbur.net}"
-BASE_DIR="${2:-/usr/local}"
+REMOTE_HOST="ci-installer@ci.ctbur.net"
+BASE_DIR="/opt/ci-server"
 
-# Set up an SSH agent to supply the key from an env var
 if [ "$CI" = "true" ]; then
     echo "Running in CI mode: Starting SSH Agent and loading key from environment"
 
@@ -37,12 +36,12 @@ else
 fi
 
 echo "Copying files..."
-# TODO: this script can probably be simplified given that now we only have one binary to copy
-rsync -e "ssh ${SSH_OPTS}" -avz "./build/ci-server" "${REMOTE_HOST}:${BASE_DIR}/bin/ci-server"
+rsync -e "ssh ${SSH_OPTS}" -avz "./build/ci-server" "./ci.service" "${REMOTE_HOST}:${BASE_DIR}/"
 echo ""
 
 echo "Restarting service..."
-ssh ${SSH_OPTS} "${REMOTE_HOST}" "systemctl restart ci.service"
+ssh ${SSH_OPTS} "${REMOTE_HOST}" "sudo /usr/bin/systemctl daemon-reload"
+ssh ${SSH_OPTS} "${REMOTE_HOST}" "sudo /usr/bin/systemctl restart ci.service"
 echo ""
 
 echo "Done"


### PR DESCRIPTION
- Install to /opt/ci-server
- Use a dedicated installer user instead of root